### PR TITLE
Update CSV.php

### DIFF
--- a/src/PhpOrient/Protocols/Binary/Serialization/CSV.php
+++ b/src/PhpOrient/Protocols/Binary/Serialization/CSV.php
@@ -232,7 +232,9 @@ class CSV {
 
         if ( $c === 'a' || $c === 't' ) {
             # date / 1000
-            $collected = \DateTime::createFromFormat( 'U', substr( $collected, 0, -3 ) );
+            $aDate = new \DateTime();
+            // Changed to support negative unixtimestamp values (dates before 1970)
+            $collected = $aDate->setTimestamp(substr( $collected, 0, -3 ));
             $input     = substr( $input, 1 );
         } elseif ( $c === 'f' ) {
             // float


### PR DESCRIPTION
Dates before 1970 has a negative unix timestamp. The existing code 

\DateTime::createFromFormat( 'U', substr( $collected, 0, -3 ) );

was not handling negative timestamp values. This change is a more effective use of DateTime object and it is able to handle negative timestamps.